### PR TITLE
bugfix for ansible v < 2.8

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,6 +4,7 @@
 cis_target_os_distribution: "Amazon"
 cis_target_os_versions: 
   - "(Karoo)"
+  - "2"
 
 cis_modprobe_conf_filename: "/etc/modprobe.d/CIS.conf"
 cis_rescue_service_filename: "/usr/lib/systemd/system/rescue.service"


### PR DESCRIPTION
See https://github.com/ansible/ansible/issues/48823


In ansible version >= 2.8 `ansible_distribution_version` returns `"2"` instead of `("Karoo")`